### PR TITLE
try / catch when profile isn't parsed

### DIFF
--- a/JAPEGrammars/AddressFinder.jape
+++ b/JAPEGrammars/AddressFinder.jape
@@ -40,12 +40,16 @@ Rule: AddressRule
 
 	if(addressSet != null && addressSet.size() > 0){
 		//Try to find the address within the most probable location (first 10 lines of the document; a.k.a within the first page)
-		AnnotationSet addresses = addressSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
-		if(addresses != null && addresses.size() > 0 && addressSet.lastNode().getOffset() <= profileSection.lastNode().getOffset()){
-			FeatureMap features = Factory.newFeatureMap();
-			features.put("rule","AddressRule");
-			features.put("kind","address");
-			outputAS.add(addresses.firstNode(),addresses.lastNode(),"AddressFinder",features);
-		}
+    try {
+      AnnotationSet addresses = addressSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
+      if(addresses != null && addresses.size() > 0 && addressSet.lastNode().getOffset() <= profileSection.lastNode().getOffset()){
+        FeatureMap features = Factory.newFeatureMap();
+        features.put("rule","AddressRule");
+        features.put("kind","address");
+        outputAS.add(addresses.firstNode(),addresses.lastNode(),"AddressFinder",features);
+      }
+    } catch (Exception e) {
+      // no address found
+    }
 	}
 }

--- a/JAPEGrammars/EmailFinder.jape
+++ b/JAPEGrammars/EmailFinder.jape
@@ -13,12 +13,16 @@ Rule: EmailRule
 
 	if(addressSet != null && addressSet.size() > 0){
 		//Try to find the address within the most probable location (first 10 lines of the document; a.k.a within the first page)
-		AnnotationSet addresses = addressSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
-		if(addresses != null && addresses.size() > 0 && addressSet.lastNode().getOffset() <= profileSection.lastNode().getOffset()){
+		try {
+			AnnotationSet addresses = addressSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
+			if(addresses != null && addresses.size() > 0 && addressSet.lastNode().getOffset() <= profileSection.lastNode().getOffset()){
 				FeatureMap features = Factory.newFeatureMap();
 				features.put("rule","EmailRule");
 				features.put("kind","email");
 				outputAS.add(addresses.firstNode(),addresses.lastNode(),"EmailFinder",features);
+			}
+		} catch(Exception e) {
+			// not possible
 		}
 	}
 }

--- a/JAPEGrammars/PhoneFinder.jape
+++ b/JAPEGrammars/PhoneFinder.jape
@@ -13,12 +13,16 @@ Rule: PhoneRule
 
 	if(addressSet != null && addressSet.size() > 0){
 		//Try to find the address within the most probable location (first 10 lines of the document; a.k.a within the first page)
+		try {
 		AnnotationSet addresses = addressSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
 		if(addresses != null && addresses.size() > 0 && addressSet.lastNode().getOffset() <= profileSection.lastNode().getOffset()){
 				FeatureMap features = Factory.newFeatureMap();
 				features.put("rule","PhoneRule");
 				features.put("kind","phone");
 				outputAS.add(addresses.firstNode(),addresses.lastNode(),"PhoneFinder",features);
+		}
+		} catch (Exception e) {
+			// no phone found
 		}
 	}
 }

--- a/JAPEGrammars/TitleFinder.jape
+++ b/JAPEGrammars/TitleFinder.jape
@@ -13,13 +13,17 @@ Rule: TitleRule
 
 	if(titleSet != null && titleSet.size() > 0){
 		//Try to find the title within the most probable location (first 10 lines of the document; a.k.a within the first page)
-		AnnotationSet titles = titleSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
-		if(titles != null && titles.size() > 0){
-			Annotation title = titles.iterator().next();
-			FeatureMap features = title.getFeatures();
-			features.put("rule","TitleRule");
-			features.put("kind","title");
-			outputAS.add(title.getStartNode(),title.getEndNode(),"TitleFinder",features);
+		try {
+			AnnotationSet titles = titleSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
+			if(titles != null && titles.size() > 0){
+				Annotation title = titles.iterator().next();
+				FeatureMap features = title.getFeatures();
+				features.put("rule","TitleRule");
+				features.put("kind","title");
+				outputAS.add(title.getStartNode(),title.getEndNode(),"TitleFinder",features);
+			}
+		} catch (Exception e) {
+			// no title
 		}
 	}
 }

--- a/JAPEGrammars/URLFinder.jape
+++ b/JAPEGrammars/URLFinder.jape
@@ -13,12 +13,16 @@ Rule: URLRule
 
 	if(addressSet != null && addressSet.size() > 0){
 		//Try to find the URL address within the most probable location (first 10 lines of the document; a.k.a within the first page)
-		AnnotationSet addresses = addressSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
-		if(addresses != null && addresses.size() > 0 && addressSet.lastNode().getOffset() <= profileSection.lastNode().getOffset()){
-				FeatureMap features = Factory.newFeatureMap();
-				features.put("rule","URLRule");
-				features.put("kind","url");
-				outputAS.add(addresses.firstNode(),addresses.lastNode(),"URLFinder",features);
+		try {
+			AnnotationSet addresses = addressSet.getContained(profileSection.firstNode().getOffset(),profileSection.lastNode().getOffset());
+			if(addresses != null && addresses.size() > 0 && addressSet.lastNode().getOffset() <= profileSection.lastNode().getOffset()){
+					FeatureMap features = Factory.newFeatureMap();
+					features.put("rule","URLRule");
+					features.put("kind","url");
+					outputAS.add(addresses.firstNode(),addresses.lastNode(),"URLFinder",features);
+			}
+		} catch (Exception e) {
+			//no url
 		}
 	}
 }


### PR DESCRIPTION
If a resume's name isn't properly parsed, it blows up all the other downstream modules.  Adding some try catch.  Open to suggestion on what to do in the `catch`, this PR just keeps the parsing from failing.